### PR TITLE
fix: update PackageReference for vulnerable report

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -4,6 +4,7 @@
         <CentralPackageFloatingVersionsEnabled>true</CentralPackageFloatingVersionsEnabled>
     </PropertyGroup>
     <ItemGroup>
+        <PackageVersion Include="AngleSharp" Version="1.*" />
         <PackageVersion Include="Aspire.Hosting.Docker" Version="13.*" />
         <PackageVersion Include="BenchmarkDotNet" Version="0.*" />
         <PackageVersion Include="bunit" Version="2.*" />

--- a/Wizdle.Web.Unit.Tests/Wizdle.Web.Unit.Tests.csproj
+++ b/Wizdle.Web.Unit.Tests/Wizdle.Web.Unit.Tests.csproj
@@ -4,6 +4,7 @@
     </PropertyGroup>
 
     <ItemGroup>
+        <PackageReference Include="AngleSharp" />
         <PackageReference Include="bunit" />
         <PackageReference Include="NUnit" />
     </ItemGroup>


### PR DESCRIPTION
update `AngleSharp` vulnerability 